### PR TITLE
Fix example for KubeOps

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -1194,7 +1194,7 @@ Example:
     args:
       operation: create
       namespace: "{{ .Deployment.Namespace }}"
-      spec:
+      spec: |-
         apiVersion: apps/v1
         kind: Deployment
         metadata:


### PR DESCRIPTION
`spec` needs to be a string

## Change Overview

<!-- Insert PR description-->

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [ ] :rainbow: Refactoring (no functional changes, no api changes)
- [ ] :hamster: Trivial/Minor
- [ ] :bug: Bugfix
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
- [ ] :robot: Test

## Issues

- #XXX

## Test Plan

<!-- Will run prior to merging.-->
<!-- Include example how to run.-->

- [ ] :muscle: Manual
- [ ] :zap: Unit test
- [ ] :green_heart: E2E
